### PR TITLE
chore: export all functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "zkvm")]
 mod zkvm_impl;
 #[cfg(feature = "zkvm")]
-pub use zkvm_impl::hash_fixed;
+pub use zkvm_impl::*;
 
 #[cfg(not(feature = "zkvm"))]
 mod dynamic_impl;
 #[cfg(not(feature = "zkvm"))]
-pub use dynamic_impl::hash_fixed;
+pub use dynamic_impl::*;


### PR DESCRIPTION
Turns out we use other functions from this crate which were not exported like `hash32_concat`