### PR TITLE
feat: make ring not compile on zkvm's, but used on everything else

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,21 +5,24 @@ edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 description = "Hashing primitives used in Ethereum, using sha2 (RISC-V compatible)"
-repository = "https://github.com/syjn99/ethereum_hashing"
+repository = "https://github.com/ReamLabs/ethereum_hashing"
 documentation = "https://docs.rs/ethereum_hashing"
 keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 rust-version = "1.80.0"
 
+[features]
+default = ["zero_hash_cache"]
+zero_hash_cache = []
+
 [dependencies]
 sha2 = "0.10"
+
+[target.'cfg(not(target_os = "zkvm"))'.dependencies]
+ring = "0.17"
 
 [dev-dependencies]
 rustc-hex = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.33"
-
-[features]
-default = ["zero_hash_cache"]
-zero_hash_cache = []

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build: # Build the Ream binary into `target` directory.
 .PHONY: test
 test: # Run all tests.
 	cargo test --workspace -- --nocapture
-	cargo test --no-default-features --features=poseidon2,zero_hash_cache
+	cargo test --no-default-features --features=zero_hash_cache
 
 ##@ Others
 .PHONY: clean
@@ -39,7 +39,7 @@ lint: # Run `clippy` and `rustfmt`.
 
 	# clippy for bls with supranational feature
 	cargo clippy --all-targets --no-deps -- --deny warnings
-	cargo clippy --all-targets --no-default-features --features=poseidon2,zero_hash_cache --no-deps -- --deny warnings
+	cargo clippy --all-targets --no-default-features --features=zero_hash_cache --no-deps -- --deny warnings
 
 	# cargo sort
 	cargo sort --grouped

--- a/src/ring_impl.rs
+++ b/src/ring_impl.rs
@@ -1,0 +1,38 @@
+//! Implementation of SHA256 using the `ring` crate (fastest on CPUs without SHA extensions).
+#![cfg(not(target_os = "zkvm"))]
+
+use crate::{Sha256, Sha256Context, HASH_LEN};
+
+pub struct RingImpl;
+
+impl Sha256Context for ring::digest::Context {
+    fn new() -> Self {
+        Self::new(&ring::digest::SHA256)
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        self.update(bytes)
+    }
+
+    fn finalize(self) -> [u8; HASH_LEN] {
+        let mut output = [0; HASH_LEN];
+        output.copy_from_slice(self.finish().as_ref());
+        output
+    }
+}
+
+impl Sha256 for RingImpl {
+    type Context = ring::digest::Context;
+
+    fn hash(&self, input: &[u8]) -> Vec<u8> {
+        ring::digest::digest(&ring::digest::SHA256, input)
+            .as_ref()
+            .into()
+    }
+
+    fn hash_fixed(&self, input: &[u8]) -> [u8; HASH_LEN] {
+        let mut ctxt = Self::Context::new(&ring::digest::SHA256);
+        ctxt.update(input);
+        ctxt.finalize()
+    }
+}

--- a/src/sha2_impl.rs
+++ b/src/sha2_impl.rs
@@ -1,7 +1,3 @@
-// This implementation should only be compiled on x86_64 due to its dependency on the `sha2` and
-// `cpufeatures` crates which do not compile on some architectures like RISC-V.
-#![cfg(target_arch = "x86_64")]
-
 use crate::{Sha256, Sha256Context, HASH_LEN};
 use sha2::Digest;
 


### PR DESCRIPTION
fix's https://github.com/ReamLabs/ream/issues/658

Sha2 is incredibly slow on MacOS, previously in https://github.com/ReamLabs/ethereum_hashing/commit/9b09a7ae3416149d1a9fd673daaa3f4a1bd8c8fb

we removed ring support from this library. Sha2 might be faster on x86 haven't tested it yet. But now this library will be a lot faster on Mac's and still compile to Riscv